### PR TITLE
Sync w/ established course controller

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -144,6 +144,43 @@ paths:
               schema:
                 $ref: "#/components/schemas/Course"
 
+  /admin/course/{course_id}/update:
+    put:
+      tags:
+        - admin
+      operationId: sync_course
+      summary: "Sync with established course controller"
+      description: |
+        Syncs with a course in the controller.
+      security:
+        - openIDC: [ admin:write ]
+      parameters:
+        - name: course_id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "999-9999-9999-99"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Course"
+      responses:
+        201:
+          description: "Accepted"
+        404:
+          description: Course Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error_source: "update_course"
+                error_message: "Course '999-9999-9999-99' does not exist"
+
   /admin/course/{course_id}/students:
     put:
       tags:


### PR DESCRIPTION
Need some extra clarifications behind this ticket

My current interpretation is that there is a course object in the back-end that syncs onto the database, but this seems obselete, given the update courses openapi request.