### PR TITLE
Backend Create User Route

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -176,12 +176,6 @@ paths:
           schema:
             type: string
             example: "999-9999-9999-99"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Course"
       responses:
         201:
           description: "Accepted"


### PR DESCRIPTION
Closes #40 
Added create user route
also removed the `items:` attribute for the request body in the sync course put request.

