### PR TITLE
Fix post field for extension requests

### DIFF
--- a/packtrain-frontend/apps/student/src/pages/ExtensionForm.tsx
+++ b/packtrain-frontend/apps/student/src/pages/ExtensionForm.tsx
@@ -97,7 +97,7 @@ export function ExtensionForm() {
     postForm.mutate(
       {
         body: {
-          user_requester_id: auth.user?.profile.id as string,
+          user_requester: auth.user?.profile.id as string,
           assignment_id: values.assignmentId,
           date_submitted: new Date().toISOString(),
           num_days_requested: numDaysRequested,
@@ -121,7 +121,7 @@ export function ExtensionForm() {
     postForm.mutate(
       {
         body: {
-          user_requester_id: auth.user?.profile.id as string,
+          user_requester: auth.user?.profile.id as string,
           assignment_id: values.assignmentId,
           date_submitted: new Date().toISOString(),
           num_days_requested: numDaysRequested,


### PR DESCRIPTION
I don't think this matters since `StudentApiImpl#createExtensionRequest` uses the `SecurityManager` user anyways, but it was erroring. The DTO requires it though for the backend when it's sending in other situations.