### PR TITLE
Dont fail if section exists

### DIFF
--- a/packtrain-service/src/main/java/edu/mines/packtrain/services/SectionService.java
+++ b/packtrain-service/src/main/java/edu/mines/packtrain/services/SectionService.java
@@ -79,8 +79,9 @@ public class SectionService {
 
     public Optional<Section> createSection(long canvasId, String name, Course course) {
         if (sectionRepo.existsByCanvasId(canvasId)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, String.format("Section " +
-                    "'%s' already exists, can not create section with same id!", name));
+            return Optional.empty();
+            // throw new ResponseStatusException(HttpStatus.BAD_REQUEST, String.format("Section " +
+            //         "'%s' already exists, can not create section with same id!", name));
         }
 
         Section newSection = new Section();


### PR DESCRIPTION
Fixes course sync error

We should do something more akin to assignment service and member service to reconcile the sections
