### PR TITLE
Dont refuse to grade if PL users dont exist

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,7 @@ http {
     sendfile        on;
 
     server {
+        client_max_body_size 0;
         server_name localhost.dev;
         listen 80;
         listen 443 ssl;

--- a/packtrain-frontend/packages/api/src/openapi.d.ts
+++ b/packtrain-frontend/packages/api/src/openapi.d.ts
@@ -738,7 +738,7 @@ declare namespace Components {
              * example:
              * 10
              */
-            externalServiceMaxScore?: number; // double
+            externalMaxScore?: number; // double
             initialDueDate?: string; // date-time
             submissionDate?: string; // date-time
             submissionStatus?: "missing" | "excused" | "late" | "extended" | "on_time";

--- a/packtrain-frontend/packages/api/src/openapi.json
+++ b/packtrain-frontend/packages/api/src/openapi.json
@@ -2815,7 +2815,7 @@
             "format": "double",
             "example": 10
           },
-          "externalServiceMaxScore": {
+          "externalMaxScore": {
             "type": "number",
             "format": "double",
             "example": 10

--- a/packtrain-service/src/main/java/edu/mines/packtrain/services/CourseMemberService.java
+++ b/packtrain-service/src/main/java/edu/mines/packtrain/services/CourseMemberService.java
@@ -452,14 +452,19 @@ public class CourseMemberService {
     }
 
     public Optional<String> getCwidGivenCourseAndEmail(String email, Course course) {
-        User user = userService.getUserByEmail(email);
+        Optional<User> user = userService.findUserByEmail(email);
 
-        if (!courseMemberRepo.existsByCourseAndUser(course, user)) {
-            log.warn("User '{}' is not enrolled in course '{}'", user.getEmail(), course.getCode());
+        if (user.isEmpty()){
+            log.warn("User '{}' does not exist in system!", email);
             return Optional.empty();
         }
 
-        return Optional.of(user.getCwid());
+        if (!courseMemberRepo.existsByCourseAndUser(course, user.get())) {
+            log.warn("User '{}' is not enrolled in course '{}'", user.get().getEmail(), course.getCode());
+            return Optional.empty();
+        }
+
+        return Optional.of(user.get().getCwid());
     }
 
     public String getCanvasIdGivenCourseAndCwid(String cwid, Course course) {

--- a/packtrain-service/src/main/java/edu/mines/packtrain/services/RawScoreService.java
+++ b/packtrain-service/src/main/java/edu/mines/packtrain/services/RawScoreService.java
@@ -224,6 +224,11 @@ public class RawScoreService {
 
         RawScore s = new RawScore();
 
+        if (line[USER_ID_IDX].isEmpty() || line[USER_ID_IDX].isBlank()){
+            log.warn("Empty student submission: {}. Skipping.", Arrays.toString(line));
+            return Optional.empty();
+        }
+
         Optional<String> cwid = courseMemberService.getCwidGivenCourseAndEmail(line[USER_ID_IDX],
                 course);
 

--- a/packtrain-service/src/main/java/edu/mines/packtrain/services/UserService.java
+++ b/packtrain-service/src/main/java/edu/mines/packtrain/services/UserService.java
@@ -33,6 +33,10 @@ public class UserService {
         return userRepo.getByCwid(cwid);
     }
 
+    public Optional<User> findUserByEmail(String email) {
+        return userRepo.getByEmail(email);
+    }
+
     public User getUserByCwid(String cwid) {
         Optional<User> user = userRepo.getByCwid(cwid);
         if (user.isEmpty()) {


### PR DESCRIPTION
Basically, skip blank users (occurs if everyone leaves a group).
If a user doesn't exist (like a TA) then dont throw a 404 error.
